### PR TITLE
Moving react and react dom to peer depencencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
   "author": "Stefano Pastore (step848@gmail.com)",
   "license": "ISC",
   "dependencies": {
-    "react": "^15.3.2",
-    "react-dom": "^15.3.2",
     "reselect": "^2.5.4"
   },
   "devDependencies": {
@@ -44,6 +42,12 @@
     "react-redux": "^4.4.5",
     "redux": "^3.6.0",
     "redux-thunk": "^2.1.0",
-    "rimraf": "^2.5.4"
+    "rimraf": "^2.5.4",
+    "react": "^15.3.2",
+    "react-dom": "^15.3.2"
+  },
+  "peerDependencies": {
+    "react": "^15.3.2",
+    "react-dom": "^15.3.2"
   }
 }


### PR DESCRIPTION
I moved `react` and `react-dom` from dependencies to peerDependencies to avoid the duplication of react library in my app. Details here: https://reactjs.org/warnings/refs-must-have-owner.html

Please accept my improvements.